### PR TITLE
Basic Dark Mode Form Styling

### DIFF
--- a/src/renderer/components/forms/index.tsx
+++ b/src/renderer/components/forms/index.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import styled from '@emotion/styled'
 import { themeValues, fontWeights } from '../../theme'
 import { css } from '@emotion/core'
@@ -41,4 +42,134 @@ export const Help = styled.p`
   margin-top: 0.25rem;
 `
 
-export const Input = styled.input``
+export const Input = styled.input`
+  &[type=text] {
+    padding: 10px;
+    height: 40px;
+    width: 100%;
+    border-radius: 4px;
+    box-sizing: border-box;
+    font-size: 16px;
+    color: #dcddde; /* TODO: extract this to a variable for a theme */
+    background-color: rgba(0, 0, 0, .1);
+    border: 1px solid rgba(0,0,0,.3);
+  }
+  &[type=text]:focus {
+    border: 1px solid rgb(114,137,218) !important; 
+  }
+  &[type=text]:hover {
+    border: 1px solid rgba(0,0,0,.7);
+  }
+  &[type=number] {
+    padding: 10px;
+    height: 40px;
+    width: 100%;
+    border-radius: 4px;
+    box-sizing: border-box;
+    font-size: 16px;
+    color: #dcddde; 
+    background-color: rgba(0, 0, 0, .1);
+    border: 1px solid rgba(0,0,0,.3);
+  }
+  &[type=number]:focus { /* TODO: extract this to variable for themes */
+    border: 1px solid rgb(114,137,218) !important; 
+  }
+  &[type=number]:hover {
+    border: 1px solid rgba(0,0,0,.7);
+  }
+  &[type=number]::-webkit-inner-spin-button { /* This hides the arrows of the number input */
+    -webkit-appearance: none;
+  }
+  &[type=submit] {
+    background-color: rgba(114,137,218, 1);
+    border: 1px solid rgba(0,0,0,.3) ;
+    border-radius: 4px;
+    color: white;
+    padding: 10px 20px;
+    text-decoration: none;
+    margin: 5px 4px;
+    cursor: pointer;  
+  }
+  &[type=submit]:focus {
+    border-color: rgba(170,200,255, .7);
+  }
+  &[type=submit]:hover {
+    background-color: rgba(105,130,210, .9);
+  }
+  &[type=submit]:active{
+    background-color: rgba(100,120,200, .9);
+  }
+`
+
+const CheckboxDiv = styled.div`
+
+display: inline-block;
+align-items: center;
+margin: 0;
+vertical-align: text-bottom;
+
+input[type=checkbox] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.md_checkbox__tick {
+  position: relative;
+  cursor: pointer;
+}
+
+.md_checkbox__tick::before { /* Box is Not Checked */
+  content: '';
+  display: block;
+  margin: 0 3px;
+  height: 18px;
+  width: 18px;
+  border: 1px rgba(0,0,0,.7) solid;
+  border-radius: 4px;
+  background-color: rgba(255, 255, 255, .1);
+}
+
+input[type=checkbox]:focus+.md_checkbox__tick::before {
+  border: 1px solid rgb(114,137,218) !important; 
+}
+
+input[type=checkbox]:checked+.md_checkbox__tick::before { /* Styling when Box is Checked */
+  background: rgba(0, 0, 0, .3);
+}
+
+input[type=checkbox]:disabled+.md_checkbox__tick::before {
+  background: #bbb; /* TODO : Theme */
+  border-color: rgba(0,0,0,5);
+}
+
+input[type=checkbox]+.md_checkbox__tick::after { /* Box is Checked */
+  content: '✓';
+  position: absolute;
+  line-height: 18px;
+  text-align: center;
+  color: #dcddde; /* TODO: theme */
+  top: 0px;
+  left: 0px;
+  margin: 0 3px;
+  height: 17px;
+  width: 17px;
+  opacity: 0;
+}
+
+input[type=checkbox]:checked+.md_checkbox__tick::after {
+  opacity: 1;
+}
+`
+
+interface ICheckboxProps {
+  checked: boolean,
+  onChange: () => void,
+}
+
+export const Checkbox = (props: ICheckboxProps) => (
+  <CheckboxDiv>
+    <input checked={props.checked} onChange={props.onChange} type="checkbox" />
+    <span className="md_checkbox__tick" />
+  </CheckboxDiv>
+);

--- a/src/renderer/components/settings-modal/display.tsx
+++ b/src/renderer/components/settings-modal/display.tsx
@@ -12,12 +12,11 @@ interface ISettingsModalProps {
 
 const SettingsModal = (props: ISettingsModalProps) => (
   <Modal open={props.visible} onClose={props.onClose} title="Settings">
-    <form onSubmit={() => {}}>
+    <form onSubmit={(e) => { e.preventDefault(); }}>
       <Form.Field>
         <Form.Label>Scrollback</Form.Label>
         <Form.Control>
-          <Form.Input
-            type="checkbox"
+          <Form.Checkbox
             checked={props.settings.scrollback}
             onChange={() => {
               props.onUpdate({ scrollback: !props.settings.scrollback })
@@ -25,120 +24,114 @@ const SettingsModal = (props: ISettingsModalProps) => (
           />
         </Form.Control>
       </Form.Field>
-      <label>
+      <Form.Label>
         Scrollback Lines:
-        <input
+        <Form.Input
           type="number"
           value={props.settings.scrollbackLines}
           onChange={e => {
             props.onUpdate({ scrollbackLines: e.target.valueAsNumber })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Timestamps:
-        <input
-          type="checkbox"
+        <Form.Checkbox
           checked={props.settings.timestamps}
           onChange={() => {
             props.onUpdate({ timestamps: !props.settings.timestamps })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Time Format:
-        <input
+        <Form.Input
           type="text"
           value={props.settings.timeFormat}
           onChange={e => {
             props.onUpdate({ timeFormat: e.target.value })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         URL Grabber:
-        <input
-          type="checkbox"
+        <Form.Checkbox
           checked={props.settings.urlgrabber}
           onChange={() => {
             props.onUpdate({ urlgrabber: !props.settings.urlgrabber })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Max URL Length:
-        <input
+        <Form.Input
           type="number"
           value={props.settings.maxurl}
           onChange={e => {
             props.onUpdate({ maxurl: e.target.valueAsNumber })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Auto-Away:
-        <input
-          type="checkbox"
+        <Form.Checkbox
           checked={props.settings.autoaway}
           onChange={() => {
             props.onUpdate({ autoaway: !props.settings.autoaway })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Quit Message:
-        <input
+        <Form.Input
           type="text"
           value={props.settings.defquit}
           onChange={e => {
             props.onUpdate({ defquit: e.target.value })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Leave Message:
-        <input
+        <Form.Input
           type="text"
           value={props.settings.defleave}
           onChange={e => {
             props.onUpdate({ defleave: e.target.value })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Away Message:
-        <input
+        <Form.Input
           type="text"
           value={props.settings.defaway}
           onChange={e => {
             props.onUpdate({ defaway: e.target.value })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Show Away Once:
-        <input
-          type="checkbox"
+        <Form.Checkbox
           checked={props.settings.showawayonce}
           onChange={() => {
             props.onUpdate({ showawayonce: !props.settings.showawayonce })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Hide Join:
-        <input
-          type="checkbox"
+        <Form.Checkbox
           checked={props.settings.hidejoin}
           onChange={() => {
             props.onUpdate({ hidejoin: !props.settings.hidejoin })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Hide Nickname Change:
-        <input
-          type="checkbox"
+        <Form.Checkbox
           checked={props.settings.hidenicknamechange}
           onChange={() => {
             props.onUpdate({
@@ -146,60 +139,59 @@ const SettingsModal = (props: ISettingsModalProps) => (
             })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Download Folder:
-        <input
+        <Form.Input
           type="text"
           value={props.settings.downloadFolder}
           onChange={e => {
             props.onUpdate({ downloadFolder: e.target.value })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Sound Channel:
-        <input
-          type="checkbox"
+        <Form.Checkbox
           checked={props.settings.soundChannel}
           onChange={() => {
             props.onUpdate({ soundChannel: !props.settings.soundChannel })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Sound Private:
-        <input
-          type="checkbox"
+        <Form.Checkbox
           checked={props.settings.soundPrivate}
           onChange={() => {
             props.onUpdate({ soundPrivate: !props.settings.soundPrivate })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Username:
-        <input
+        <Form.Input
           type="text"
           value={props.settings.userName}
           onChange={e => {
             props.onUpdate({ userName: e.target.value })
           }}
         />
-      </label>
-      <label>
+      </Form.Label>
+      <Form.Label>
         Real Name:
-        <input
+        <Form.Input
           type="text"
           value={props.settings.realName}
           onChange={e => {
             props.onUpdate({ realName: e.target.value })
           }}
         />
-      </label>
-      <input type="submit" value="Save" />
+      </Form.Label>
+      <Form.Input type="submit" value="Save" onClick={props.onClose} />
     </form>
   </Modal>
 )
+// TODO: add onSave functionality
 
 export default SettingsModal


### PR DESCRIPTION
Added some basic dark mode styling as a PoC for the settings menu. Additional work is required to get the light mode settings up to spec as well, but hopefully this helps kickstart things for guidelines / etc.

Also removed the default form submit on enter while updating the settings form to help with keyboard navigation of the app.