### PR TITLE
Asynchronous Connection Status

### DIFF
--- a/src/renderer/components/left-panel/display.tsx
+++ b/src/renderer/components/left-panel/display.tsx
@@ -22,8 +22,24 @@ import {
   FaHashtag,
   FaRegTimesCircle,
   FaRegCheckCircle,
+  FaRegHourglass,
 } from 'react-icons/fa'
-import { IChannel, IServer } from '../../store/connections/types'
+import {
+  IChannel,
+  IServer,
+  ConnectionStatus,
+} from '../../store/connections/types'
+
+const getIcon = (status: ConnectionStatus) => {
+  switch (status) {
+    case ConnectionStatus.NotConnected:
+      return <FaRegTimesCircle />
+    case ConnectionStatus.Connecting:
+      return <FaRegHourglass />
+    case ConnectionStatus.Connected:
+      return <FaRegCheckCircle />
+  }
+}
 
 const makeVirtualReference = (
   x: number,
@@ -157,11 +173,7 @@ class Channel extends React.Component<IChannelProps, {}> {
                 margin-left: auto;
               `}
             >
-              {this.props.channel.connected ? (
-                <FaRegCheckCircle />
-              ) : (
-                <FaRegTimesCircle />
-              )}
+              {getIcon(this.props.channel.connected)}
             </Icon>
           </ChannelName>
         </ServerLinkLayout>
@@ -298,11 +310,7 @@ class Server extends React.Component<IServerProps, IServerState> {
                 margin-left: auto;
               `}
             >
-              {this.props.server.connected ? (
-                <FaRegCheckCircle />
-              ) : (
-                <FaRegTimesCircle />
-              )}
+              {getIcon(this.props.server.connected)}
             </Icon>
           </ServerName>
         </ServerLinkLayout>

--- a/src/renderer/components/message-entry/display.tsx
+++ b/src/renderer/components/message-entry/display.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import styled from '@emotion/styled'
 import { themeValues, fontWeights } from '../../theme'
-import { IChannel } from '../../store/connections/types'
+import { IChannel, ConnectionStatus } from '../../store/connections/types'
 
 const SendMessageForm = styled.form`
   border-top: 1px solid ${themeValues.backgroundModifierAccent};
@@ -86,7 +86,11 @@ class ChatBox extends React.Component<IChatBoxProps, IChatBoxState> {
               <TextInput
                 type="text"
                 placeholder="Send a message"
-                disabled={this.props.selectedChannel === undefined}
+                disabled={
+                  this.props.selectedChannel === undefined ||
+                  this.props.selectedChannel.connected !==
+                    ConnectionStatus.Connected
+                }
                 value={this.state.message}
                 onChange={e => {
                   this.setState({ message: e.target.value })

--- a/src/renderer/store/connections/actions.ts
+++ b/src/renderer/store/connections/actions.ts
@@ -1,6 +1,7 @@
 import {
   IMessage,
   ConnectionsActionTypes,
+  ConnectionStatus,
   ADD_SERVER,
   REMOVE_SERVER,
   CONNECT_TO_SERVER,
@@ -56,7 +57,7 @@ export function disconnectFromServer(serverId: string): ConnectionsActionTypes {
 
 export function markServerStatus(
   serverId: string,
-  connected: boolean
+  connected: ConnectionStatus
 ): ConnectionsActionTypes {
   return {
     type: MARK_SERVER_STATUS,
@@ -119,7 +120,7 @@ export function partChannel(
 export function markChannelStatus(
   serverId: string,
   channelId: string,
-  connected: boolean
+  connected: ConnectionStatus
 ): ConnectionsActionTypes {
   return {
     type: MARK_CHANNEL_STATUS,

--- a/src/renderer/store/connections/reducers.ts
+++ b/src/renderer/store/connections/reducers.ts
@@ -1,6 +1,7 @@
 import {
   IConnectionsState,
   ConnectionsActionTypes,
+  ConnectionStatus,
   REMOVE_SERVER,
   SELECT_SERVER,
   ADD_CHANNEL,
@@ -42,7 +43,7 @@ function connectionsReducer(
               serverId: sId,
               name: '#',
               log: [],
-              connected: false,
+              connected: ConnectionStatus.NotConnected,
               isUnread: false,
             },
             ...action.channels.map(c => ({
@@ -50,12 +51,12 @@ function connectionsReducer(
               serverId: sId,
               name: c,
               log: [],
-              connected: false,
+              connected: ConnectionStatus.NotConnected,
               isUnread: false,
             })),
           ],
           log: [],
-          connected: false,
+          connected: ConnectionStatus.NotConnected,
         })
       })
     case REMOVE_SERVER:
@@ -67,6 +68,9 @@ function connectionsReducer(
         let s = draft.servers.find(s => s.id === action.serverId)
         if (s !== undefined) {
           s.connected = action.connected
+
+          // Also mark the '#' server channel
+          s.channels.find(c => c.name === '#')!.connected = action.connected
         }
       })
     case SELECT_SERVER:
@@ -85,7 +89,7 @@ function connectionsReducer(
             serverId: action.serverId,
             name: action.channel,
             log: [],
-            connected: false,
+            connected: ConnectionStatus.NotConnected,
             isUnread: false,
           })
       })

--- a/src/renderer/store/connections/types.ts
+++ b/src/renderer/store/connections/types.ts
@@ -1,5 +1,11 @@
 import { v4 as uuid } from 'uuid'
 
+export enum ConnectionStatus {
+  NotConnected,
+  Connecting,
+  Connected,
+}
+
 export enum MessageType {
   MESSAGE,
   NICKCHANGE,
@@ -177,7 +183,7 @@ export interface IChannel {
   readonly serverId: string
   readonly name: string
   readonly log: IMessage[]
-  readonly connected: boolean
+  readonly connected: ConnectionStatus
   readonly isUnread: boolean
 }
 
@@ -189,7 +195,7 @@ export interface IServer {
   readonly defaultChannels: string[]
   readonly channels: IChannel[]
   readonly log: IMessage[]
-  readonly connected: boolean
+  readonly connected: ConnectionStatus
 }
 
 export interface IConnectionsState {
@@ -244,7 +250,7 @@ export interface IDisconnectFromServerAction {
 export interface IMarkServerStatusAction {
   type: typeof MARK_SERVER_STATUS
   serverId: string
-  connected: boolean
+  connected: ConnectionStatus
 }
 
 export interface ISelectServerAction {
@@ -280,7 +286,7 @@ export interface IMarkChannelStatusAction {
   type: typeof MARK_CHANNEL_STATUS
   serverId: string
   channelId: string
-  connected: boolean
+  connected: ConnectionStatus
 }
 
 export interface ISelectChannelAction {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We need a way to describe three states to the user (and internally):
1. The user is not connected to a server or channel.
2. The user has started the connection process for a server or channel.
3. The user is connected to a server or channel.
Because disconnection happens instantly, there is no need for a fourth state. This PR replaces the server & channel connection boolean with an enum that more accurately reflects the nature of the connections.

## Related Issue
Fixes #14 

## Motivation and Context
Previously, the user could try to connect to a server or channel and see no impact from their action. Now, the connection icon can change to an hourglass, and future UI logic can take the connection status into account.

## How Has This Been Tested?
Manual testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
