### PR TITLE
Make server channels not duplicate other channel messages

### DIFF
--- a/src/renderer/store/connections/sagas.ts
+++ b/src/renderer/store/connections/sagas.ts
@@ -297,6 +297,9 @@ function* subscribeToChannelMessage(
   channelId: string
 ) {
   let channel = getChannel(yield select(), serverId, channelId) as IChannel
+  if (channel.name == '#') {
+    return
+  }
   const evChan = eventChannel(emit => {
     const handler = (nick: string, text: string, _message: irc.IMessage) => {
       emit(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Server channels would subscribe to all channel messages (and due to the event listener, only post
the channel of received messages. This has been fixed.

## Related Issue
fixes #23 

## Motivation and Context
N/A

## How Has This Been Tested?
Manually tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
